### PR TITLE
feat: note api 기능 추가

### DIFF
--- a/routes/controllers/note.controller.js
+++ b/routes/controllers/note.controller.js
@@ -8,7 +8,7 @@ exports.getAllNotes = async (req, res, next) => {
 
 exports.getNotesByUserId = async (req, res, next) => {
   const { user_id } = req.params;
-  const notes = await NoteService.getNotesByUserId({ creator: user_id });
+  const notes = await NoteService.getNotesByCreator(user_id);
 
   return res.status(200).send(notes);
 };

--- a/routes/controllers/note.controller.js
+++ b/routes/controllers/note.controller.js
@@ -6,6 +6,13 @@ exports.getAllNotes = async (req, res, next) => {
   return res.status(200).send(notes);
 };
 
+exports.getNotesByUserId = async (req, res, next) => {
+  const { user_id } = req.params;
+  const notes = await NoteService.getNotesByUserId({ creator: user_id });
+
+  return res.status(200).send(notes);
+};
+
 exports.createNote = async (req, res, next) => {
   const newNote = req.body;
 

--- a/routes/controllers/user.controller.js
+++ b/routes/controllers/user.controller.js
@@ -1,0 +1,8 @@
+const NoteService = require("../../services/NoteService");
+
+exports.getMyNotes = async (req, res, next) => {
+  const { user_id } = req.params;
+  const notes = await NoteService.getNotesByCreator(user_id);
+
+  return res.status(200).send(notes);
+};

--- a/routes/notes.js
+++ b/routes/notes.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const noteController = require("./controllers/note.controller");
 
 router.get("/", noteController.getAllNotes);
+router.get("/:user_id", noteController.getNotesByUserId);
 router.post("/", noteController.createNote);
 router.patch("/:note_id", noteController.updateNote);
 router.patch("/:note_id/likes", noteController.updateNotePopularity);

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,9 +1,7 @@
 const express = require("express");
 const router = express.Router();
+const userController = require("./controllers/user.controller");
 
-/* GET users listing. */
-router.get("/", function (req, res, next) {
-  res.send("respond with a resource");
-});
+router.get("/:user_id/notes", userController.getMyNotes);
 
 module.exports = router;

--- a/services/NoteService.js
+++ b/services/NoteService.js
@@ -19,6 +19,21 @@ class NoteService {
     return allNotes;
   }
 
+  async getNotesByUserId(query) {
+    const results = await this.noteModel
+      .find(query)
+      .populate({
+        path: "relatedRecipe",
+        populate: {
+          path: "belongsToMenu",
+          model: "Menu",
+        },
+      })
+      .lean();
+
+    return results;
+  }
+
   async createNewNote({
     email,
     relatedRecipe,

--- a/services/NoteService.js
+++ b/services/NoteService.js
@@ -19,9 +19,9 @@ class NoteService {
     return allNotes;
   }
 
-  async getNotesByUserId(query) {
+  async getNotesByCreator(user_id) {
     const results = await this.noteModel
-      .find(query)
+      .find({ creator: user_id })
       .populate({
         path: "relatedRecipe",
         populate: {

--- a/services/RecipeService.js
+++ b/services/RecipeService.js
@@ -92,12 +92,6 @@ class RecipeService {
 
     return recipe;
   }
-
-  async getRecipesByListArray(idListArray) {
-    const results = await this.recipeModel.find({ _id: { $in: idListArray } });
-
-    return results;
-  }
 }
 
 module.exports = new RecipeService(Recipe);

--- a/services/RecipeService.js
+++ b/services/RecipeService.js
@@ -92,6 +92,12 @@ class RecipeService {
 
     return recipe;
   }
+
+  async getRecipesByListArray(idListArray) {
+    const results = await this.recipeModel.find({ _id: { $in: idListArray } });
+
+    return results;
+  }
 }
 
 module.exports = new RecipeService(Recipe);


### PR DESCRIPTION
## What is this PR? 🔍
- note api중 userId를 입력하면 해당 아이디를 가진 노트를 돌려줍니다.
- 서비스 로직에서 부득이하게 double populate가 되고 있음
   - 노트가 레시피를 참조하고 레시피는 메뉴를 참조하는 상황으로 빚어지는 문제
   - 노트가 메뉴 name을 얻기위해서 double populate외에 방법이 없는 상황
      - mongoose에도 그닥 권하지 않는 방향인듯 
      - <img width="824" alt="image" src="https://user-images.githubusercontent.com/78262571/173171031-2728554b-0afd-43d6-a221-ca424c939bd0.png">
      - 해결책은 Recipe의 모델을 수정하는 것. 허나 DB구조의 형식에서 매끄럽지 않아 보임.
      - mongoose라는 도구의 한계에서 타협점을 찾아야 할것으로 판단됩니다.
      - 일단 현재 로직은 double populate형식으로 해결했음. 추후 논의 필요!
      
## Changes 📝
- NoteService.js
- note.controller.js
- notes.js
노트와 관련된 라우터, 컨트롤러, 서비스로직 변경
## Screennshot 📷
서비스 로직
![image](https://user-images.githubusercontent.com/78262571/173170889-db0fb44e-d76c-4fec-8a52-c5b68e3f4597.png)


노트 라우터
![image](https://user-images.githubusercontent.com/78262571/173170900-b792fa8f-ca03-4180-b52b-86bf4a0aac15.png)

노트 컨트롤러
![image](https://user-images.githubusercontent.com/78262571/173170909-ac24b5ad-1544-4832-8975-a9d1adb56304.png)


## Test Checklist ✅
