### PR TITLE
Wonil feat page rankings recipe menu top10

### DIFF
--- a/routes/controllers/menu.controller.js
+++ b/routes/controllers/menu.controller.js
@@ -6,6 +6,12 @@ exports.getMenus = async (req, res, next) => {
   return res.status(200).send(menus);
 };
 
+exports.getTop5Menus = async (req, res, next) => {
+  const menus = await MenuService.getTop5Menus();
+
+  return res.status(200).send(menus);
+};
+
 exports.createMenu = async (req, res, next) => {
   const { category_id, menuName } = req.body;
 

--- a/routes/controllers/menu.controller.js
+++ b/routes/controllers/menu.controller.js
@@ -6,6 +6,13 @@ exports.getMenus = async (req, res, next) => {
   return res.status(200).send(menus);
 };
 
+exports.getMenu = async (req, res, next) => {
+  const { menu_id } = req.params;
+  const menu = await MenuService.getMenu(menu_id);
+
+  return res.status(200).send(menu);
+};
+
 exports.getTop5Menus = async (req, res, next) => {
   const menus = await MenuService.getTop5Menus();
 

--- a/routes/menus.js
+++ b/routes/menus.js
@@ -2,7 +2,6 @@ const express = require("express");
 const router = express.Router();
 const menuController = require("./controllers/menu.controller");
 
-/* GET users listing. */
-router.get("/", menuController.getMenus);
+router.get("/top5", menuController.getTop5Menus);
 
 module.exports = router;

--- a/routes/menus.js
+++ b/routes/menus.js
@@ -3,5 +3,6 @@ const router = express.Router();
 const menuController = require("./controllers/menu.controller");
 
 router.get("/top5", menuController.getTop5Menus);
+router.get("/:menu_id", menuController.getMenu);
 
 module.exports = router;

--- a/services/MenuService.js
+++ b/services/MenuService.js
@@ -1,5 +1,6 @@
 const Menu = require("../models/Menu");
 const Category = require("../models/Category");
+const Recipe = require("../models/Recipe");
 const mongoose = require("mongoose");
 
 class MenuService {
@@ -16,14 +17,66 @@ class MenuService {
       {
         $project: {
           name: 1,
-          numgerOfRecipes: { $size: "$recipes" },
+          recipes: 1,
+          numberOfRecipes: { $size: "$recipes" },
         },
       },
-      { $sort: { numgerOfRecipes: -1 } },
-      { $limit: 5 },
+      { $sort: { numberOfRecipes: -1 } },
+      { $limit: 30 },
     ]);
 
-    return results;
+    await Recipe.populate(results, {
+      path: "recipes",
+    });
+
+    await results.sort((a, b) => {
+      const aNumberOfRecipes = a.numberOfRecipes;
+      const bNumberOfRecipes = b.numberOfRecipes;
+      const aNumberOfLikes = a.recipes.reduce((prev, current) => {
+        return prev + current.liked.length;
+      }, 1);
+      const bNumberOfLikes = b.recipes.reduce((prev, current) => {
+        return prev + current.liked.length;
+      }, 1);
+      const aNumberOfDislikes = a.recipes.reduce((prev, current) => {
+        return prev + current.disliked.length;
+      }, 1);
+      const bNumberOfDislikes = b.recipes.reduce((prev, current) => {
+        return prev + current.disliked.length;
+      }, 1);
+      const aNumberOfNotes = a.recipes.reduce((prev, current) => {
+        return prev + current.notes.length;
+      }, 1);
+      const bNumberOfNotes = b.recipes.reduce((prev, current) => {
+        return prev + current.notes.length;
+      }, 1);
+      const aNumberOfTips = a.recipes.reduce((prev, current) => {
+        return prev + current.tips.length;
+      }, 1);
+      const bNumberOfTips = b.recipes.reduce((prev, current) => {
+        return prev + current.tips.length;
+      }, 1);
+
+      return (
+        bNumberOfRecipes *
+          (bNumberOfLikes - bNumberOfDislikes) *
+          bNumberOfNotes *
+          bNumberOfTips -
+        aNumberOfRecipes *
+          (aNumberOfLikes - aNumberOfDislikes) *
+          aNumberOfNotes *
+          aNumberOfTips
+      );
+    });
+
+    return results.splice(0, 5);
+  }
+
+  async getMenu(menu_id) {
+    console.log("hi");
+    const menu = this.menuModel.findById(menu_id).populate("recipes").lean();
+
+    return menu;
   }
 
   async createNewMenu(category_id, menuName) {

--- a/services/MenuService.js
+++ b/services/MenuService.js
@@ -11,6 +11,21 @@ class MenuService {
     return await this.menuModel.find().lean();
   }
 
+  async getTop5Menus() {
+    const results = await this.menuModel.aggregate([
+      {
+        $project: {
+          name: 1,
+          numgerOfRecipes: { $size: "$recipes" },
+        },
+      },
+      { $sort: { numgerOfRecipes: -1 } },
+      { $limit: 5 },
+    ]);
+
+    return results;
+  }
+
   async createNewMenu(category_id, menuName) {
     const menu = this.menuModel.find({ name: menuName.trim() });
     const category = await Category.findById(category_id);

--- a/services/NoteService.js
+++ b/services/NoteService.js
@@ -37,17 +37,16 @@ class NoteService {
 
   async getTopTenNotes() {
     const results = await this.noteModel.aggregate([
+      { $match: { visibility: true } },
       {
         $project: {
           relatedRecipe: 1,
           creator: 1,
-          visibility: 1,
           updatedAt: 1,
           numberOfLikes: { $size: "$liked" },
           numberOfDislikes: { $size: "$disliked" },
         },
       },
-      { $match: { visibility: true } },
       { $sort: { numberOfLikes: -1, updatedAt: -1 } },
       { $limit: 10 },
     ]);


### PR DESCRIPTION
## What is this PR? 🔍
- 클라이언트의 랭킹 페이지의 인기 메뉴 레시피 Top10을 위한 서버 로직 작성
- mongoose 자체적으로 계산할 수 있으면 계산하고, 최대한 정제된 데이터 작성해보내주는데 초점을 맞췄음.
- 안되는것은 서버에게 약간만 가공된 데이터를 보내주고 자체 처리하게끔 처리.
   - 메뉴 모델이 레시피 모델을 배열로 가지고 있음.
   - 그로인해 메뉴 모델에서 aggregate 명령을 하기전에 레시피 모델을 populate해야 하나 이부분은 여기저기 찾아 봤으나.mongoDB가 지원을 안하는 것으로 보여짐. aggregate에서는 한 모델 안에서만 파이프라인 처리가 가능. 다른 모델을 참조하는 것이 불가함.
   - 더 큰 범주인 레시피에서 작은 범주인 메뉴(메뉴는 그저 메뉴명만 필요하므로)로 갈때는 자연스럽게 aggregate로 데이터를 가공하고 populate할 수 있었으나
   - 반대로 menu에서  큰 범주인 recipe로 갈때는 aggregate 처리가 불가했음.
   - (**중요한 배움**)참조관계의 차이로 인해 데이터를 aggregate로 먼저 정제하고 populate를 하는것을 할 수가 없었음.
   - mongoDB에서는 데이터 스키마 구조에 따라 할 수 있는 일의 범위가 상당히 달라짐을 몸소 체감함.
   - 어쩔수 없이 꽤 큰 사이즈의 데이터를 클라이언트에 보내고 클라이언트에 처리하게 만듦음.
   - 뭔가 랭킹에 대한 비즈니스 로직은 서버로 다 몰고 싶었으나 혅재 구조상 불가능해서 개인적으로 아쉬웠음 
   - 이 경우에도 메뉴명이 레시피에 있었다면 레시피를 잘 가공할 수 있었음. 형식에 조금 유연했다면 많은 것들이 쉬워질 수 있는 케이스도 있구나를 깨달았음. 
   - 형식과 실용에 대한 적절한 선택 능력이 개발자에게 중요한 부분이라고 몸소 느꼈다. 그전에 이러한 상황이 없도록 올바른 도구 선택을 하는 능력이 더 중요할 것이고...
   - 여러모로 랭킹짜면서 DB에 대한 큰 배움이 있는 것 같아서 뿌듯합니다.

## Changes 📝
- menu관련 서비스, 컨트롤러, 라우트를 수정하였습니다.


## Screennshot 📷
Top5 메뉴 뽑는 비즈니스 로직
<img width="467" alt="image" src="https://user-images.githubusercontent.com/78262571/173243770-e0524539-0aee-4196-a37b-f57c0833ea7e.png">
- 평가점수 = 현재 해당 메뉴의 레시피 수 * (좋아요 수 - 안좋아요 수) * 해당 메뉴의 총 노트수 * 해당 메뉴의 총 꿀팁수

## Test Checklist ✅
- 메뉴관련 로직들이 올바르게 작동하는기 테스트하기
